### PR TITLE
Update readme to use npm ci over npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ $ git clone https://github.com/<username>/cinesimile.git
 3. Install node_modules.
 
 ```bash
-$ npm install
+$ npm ci
 ```
 
 4. Start the React development server.


### PR DESCRIPTION
npm install may update the package-lock.json as npm ci will download the exact versions within the package-lock.json without modifying it.